### PR TITLE
Improve script to show/hide description, closes #372, closes #370

### DIFF
--- a/input/assets/css/_general.scss
+++ b/input/assets/css/_general.scss
@@ -140,3 +140,10 @@ button {
 .alert-danger {
   border: 1px solid $valencia;
 }
+
+.morecontent span {
+  display: none;
+}
+.morelink {
+  display: block;
+}

--- a/input/assets/css/_pdp.scss
+++ b/input/assets/css/_pdp.scss
@@ -99,15 +99,16 @@
 // Product description
 .pdp-product-description {
   font-size: 0.9em;
+
+  .morelink {
+    color: $gray;
+    text-transform: uppercase;
+    text-decoration: underline;
+    font-size: 0.9em;
+  }
 }
 
 // Product information text
-.view-details {
-  color: $gray;
-  text-transform: uppercase;
-  text-decoration: underline;
-  font-size: 0.9em;
-}
 .additional-description {
   display: none;
   font-size: 0.9em;

--- a/input/assets/js/main.js
+++ b/input/assets/js/main.js
@@ -236,29 +236,35 @@ $(function() {
 
 // Toggle hidden/sliced description
 $(function() {
-  var hiddenDescription = $('p.pdp-product-description'),
-    generatedHidden,
-    shownFlag,
-    hiddenDescriptionText;
-
-  if (hiddenDescription.length) {
-    hiddenDescription = hiddenDescription.first();
-    hiddenDescriptionText = hiddenDescription.text();
-
-    if (hiddenDescriptionText.length < 100) return;
-    hiddenDescription.html(
-      hiddenDescriptionText.slice(0, 100) + '<span>... </span>' +
-      '<span class="hidden">' + hiddenDescriptionText.slice(100, hiddenDescriptionText.length) + '</span>'
-    );
-    generatedHidden = $('.hidden', hiddenDescription);
-  }
-
-  $('.view-details').click(function() {
-    if (generatedHidden && generatedHidden.length) {
-      shownFlag = !!generatedHidden.hasClass('hidden');
-      $(this).text(shownFlag ? 'Hide details' : 'View details');
-      generatedHidden.toggleClass('hidden');
+  var showChar = 300; // How many characters are shown by default
+  var ellipsestext = "...";
+  
+  $('.more').each(function() {
+    var description = $(this),
+        moretext = description.data("text-show"),
+        content = description.html();
+    if (content.length > showChar) {
+      var displayed = content.substr(0, showChar),
+          hidden = content.substr(showChar, content.length - showChar); 
+      var html = displayed + '<span class="moreellipses">' + ellipsestext+ '&nbsp;</span><span class="morecontent"><span>' + hidden + '</span>&nbsp;&nbsp;<a href="#" class="morelink">' + moretext + '</a></span>';
+      description.html(html);
     }
+  });
+
+  $(".morelink").click(function(){
+    var morelink = $(this),
+        morecontent = morelink.parent(),
+        description = morecontent.parent();
+    if(morelink.hasClass("less")) {
+      morelink.removeClass("less");
+      morelink.html(description.data("text-show"));
+    } else {
+      morelink.addClass("less");
+      morelink.html(description.data("text-hide"));
+    }
+    morecontent.prev().toggle();
+    morelink.prev().toggle();
+    return false;
   });
 });
 

--- a/input/i18n/en/catalog.yaml
+++ b/input/i18n/en/catalog.yaml
@@ -56,9 +56,11 @@ suggestions:
 reviews:
   title: Reviews
   write: Write first review
+description:
+  show: Show more
+  hide: Show less
 details:
   title: Product Details
-  view: View Details
 delivery:
   title: Delivery & Returns
   freeReturns: Free return for all orders.

--- a/input/templates/partials/catalog/pdp/product-info.hbs
+++ b/input/templates/partials/catalog/pdp/product-info.hbs
@@ -14,10 +14,7 @@
   </div>
   <div class="row">
     <div class="col-sm-12">
-      <p class="pdp-product-description">{{{product.description}}}</p>
-      <a id="pdp-view-details-btn" href="#">
-        <span class="view-details">{{i18n "catalog:details.view"}}</span>
-      </a>
+      <p class="pdp-product-description view-details more" data-text-show="{{i18n "catalog:description.show"}}" data-text-hide="{{i18n "catalog:description.hide"}}">{{{product.description}}}</p>
     </div>
   </div>
   <div class="row">

--- a/input/templates/partials/catalog/quickview.hbs
+++ b/input/templates/partials/catalog/quickview.hbs
@@ -35,13 +35,6 @@
             </div>
             <div class="row">
               <div class="col-sm-12">
-                <a href="#">
-                  <span class="view-details">{{i18n "catalog:details.view"}}</span>
-                </a>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-sm-12">
                 {{> catalog/product-price}}
               </div>
             </div>


### PR DESCRIPTION
- Doesn't show the hide/show functionality when it is not needed (description is too short)
- Allows internationalization of the show/hide messages (before it was hardcoded in JS)
- Changed the name to something less ambiguous