### PR TITLE
Fingerprint only on build for release, closes #402

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,18 +17,19 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', ['build', 'watch']);
 
-  grunt.registerTask('build', ['clean', 'internal-build-images', 'internal-build-assets', 'internal-build-templates', 'assetFingerprint']);
-  grunt.registerTask('build-images', ['clean:images', 'internal-build-images', 'assetFingerprint:images']);
-  grunt.registerTask('build-assets', ['clean:assets', 'internal-build-assets', 'assetFingerprint:assets']);
-  grunt.registerTask('build-templates', ['clean:templates', 'internal-build-templates', 'assetFingerprint']);
+  grunt.registerTask('build', ['clean', 'internal-build-images', 'internal-build-assets', 'internal-build-templates']);
+  grunt.registerTask('build-images', ['clean:images', 'internal-build-images']);
+  grunt.registerTask('build-assets', ['clean:assets', 'internal-build-assets']);
+  grunt.registerTask('build-templates', ['clean:templates', 'internal-build-templates']);
+  grunt.registerTask('build-release', ['build', 'assetFingerprint']);
 
-  grunt.registerTask('release-composer', ['build', 'copy:composer']);
+  grunt.registerTask('release-composer', ['build-release', 'copy:composer', 'clean']);
   
-  grunt.registerTask('build-webjar', ['build', 'maven:webjars']);
-  grunt.registerTask('install-webjar', ['build', 'maven:install', 'clean:dist']);
-  grunt.registerTask('release-webjar', ['build', 'maven:release', 'clean:dist']);
+  grunt.registerTask('build-webjar', ['build-release', 'maven:webjars', 'clean']);
+  grunt.registerTask('install-webjar', ['build-release', 'maven:install', 'clean']);
+  grunt.registerTask('release-webjar', ['build-release', 'maven:release', 'clean']);
 
-  grunt.registerTask('publish', ['gh-pages-clean', 'build', 'gh-pages']);
+  grunt.registerTask('publish', ['gh-pages-clean', 'build-release', 'gh-pages', 'clean']);
 
   grunt.registerTask('internal-build-images', ['copy:images', 'imagemin']);
   grunt.registerTask('internal-build-assets', ['copy:assets', 'sass', 'postcss', 'uglify']);

--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ Build the site for your theme and access the HTML files to see how it looks like
 
 - `grunt build-templates` to build only i18n and HBS files, besides generating the HTML files from the Handlebars templates and the JSON data
 
+- `grunt build-release` behaves exactly as `build`, but additionally it fingerprints all web assets
+
 Building the generated site also performs these tasks:
 - Compiles [Sass](http://sass-lang.com/) to CSS files
 - Minifies CSS and JS files
 - Adds vendor-prefixed CSS properties with [Autoprefixer](https://github.com/postcss/autoprefixer)
 - Compresses any PNG, JPG, GIF and SVG image file with [Imagemin](https://github.com/imagemin/imagemin)
-- Fingerprints all web assets
 
 #### Create WebJars File
 

--- a/tasks/options/assetFingerprint.js
+++ b/tasks/options/assetFingerprint.js
@@ -12,7 +12,7 @@ module.exports = {
     keepOriginalFiles: false
   },
 
-  images: {
+  dist: {
     files: [
       {
         expand: true,
@@ -20,19 +20,7 @@ module.exports = {
         src: [
           "img/**/*",
           "!img/cms/**/*",
-          "!img/favicon.ico"
-        ],
-        dest: "output/assets"
-      }
-    ]
-  },
-
-  assets: {
-    files: [
-      {
-        expand: true,
-        cwd: "output/assets",
-        src: [
+          "!img/favicon.ico",
           "fonts/**/*",
           "js/**/*.js"
         ],

--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   templates: {
     files: ['input/templates/**/*', 'input/i18n/**/*'],
-    tasks: ['build'] // Required for fingerprinting
+    tasks: ['build-templates']
   }
 
 }


### PR DESCRIPTION
In order to cover all cases for a successful fingerprinting, we would need to drop the watch tasks for the different areas, thus dramatically increasing the build time for each single modification, which slows down development.

Therefore fingerprinting will be only generated on release or publish, which is actually where it becomes necessary.